### PR TITLE
Zotero9

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-syllabus",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-syllabus",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "concurrently": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-syllabus",
   "type": "module",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Zotero Syllabus Plugin",
   "config": {
     "addonName": "Zotero Syllabus",


### PR DESCRIPTION
## Description
To make the plugin compatible with the latest version, just changed the addon/manifest.json parameter "strict_max_version" to "9.*".

## Motivation / Context
New Zotero major update from 8.0.5 to 9.0.0 made the extension incompatible.

## How This Has Been Tested
Only checked if the XPI file installed successfully and I could view a collection as a Syllabus. Haven't tested if data from previous installation is still there or it's compatible, or if any other functionality has broken.

## Screenshots

<img width="1011" height="965" alt="Screenshot from 2026-07-21 21-53-19" src="https://github.com/user-attachments/assets/bf717803-7747-41af-91d5-1f94b33c36d1" />
